### PR TITLE
Quick start: add crds

### DIFF
--- a/wordpress-workload/quick-start/README.md
+++ b/wordpress-workload/quick-start/README.md
@@ -19,7 +19,8 @@ and other resources needed to walk through the experience.
 
 In the examples, the following is shown:
 
-* The format of `stack.yaml`.
+* The format of `stack.yaml` (see `example.stack.yaml` for even more
+  explanation).
 * What it would look and feel like to process and create resources at
   "configure" time, when a stack is first installed.
 * How multiple different resource processing engines may be specified
@@ -73,12 +74,14 @@ it easier to configure a provider.
 Next, install the desired resource packs to set up your cloud
 infrastructure quickly.
 
+Install the stack:
+
 ```
 cat > install-resource-pack.yaml <<EOF
 apiVersion: stacks.crossplane.io/v1alpha1
 kind: StackInstall
 metadata:
-  name: "gcp-resource-pack"
+  name: "gcp-resource-pack-stack"
   namespace: dev
 spec:
   package: "github.com/suskin/template-stack-experience/wordpress-workload/quick-start/resource-packs/dev/gcp"
@@ -87,72 +90,91 @@ EOF
 kubectl apply -f install-resource-pack.yaml
 ```
 
+Apply the pack:
+
+```
+cat > apply-resource-pack.yaml <<EOF
+apiVersion: gcp.wordpress.samples.stacks.crossplane.io/v1alpha1
+kind: ResourcePack
+metadata:
+  name: "gcp-resource-pack"
+  namespace: dev
+EOF
+
+kubectl apply -f apply-resource-pack.yaml
+```
+
 ### Install app stack
 
 Next, install the app stack.
 
 #### Option 1: using the go-kustomize engine
 
-Using the go-kustomize engine:
+Install the stack:
 
 ```
-cat > install-app.yaml <<EOF
+cat > install-app-stack.yaml <<EOF
 apiVersion: stacks.crossplane.io/v1alpha1
 kind: StackInstall
 metadata:
-  name: "my-wordpress"
+  name: "my-wordpress-stack-go-kustomize"
   namespace: dev
 spec:
   # This can be a git url or a docker image repository
   package: "github.com/suskin/template-stack-experience/wordpress-workload/quick-start/app-stack/go-kustomize"
-
-  # A stack can also be installed directly from an image or url
-  # which does not have its own stack configuration. In that case,
-  # the stack configuration can be specified in the stack install itself.
-  # stackConfiguration:
-  #   title: "Wordpress Stack"
-  #   configure:
-  #     - directory: configure/
-  #       engine:
-  #         type: go-kustomize
-  #         configuration:
-  #           data:
-  #             imageid: "wordpress:5-fpm-alpine"
-
-
-  # In the case that the stack has a "configure" phase hook, the stack install
-  # can also specify configuration to be passed directly to the engine processing
-  # the hook. The configuration is namespaced so that it doesn't collide with any
-  # other configuration. In a non-install CRD, it would not need to be namespaced
-  # so aggressively, because the CRD may only be used for triggering and configuring
-  # a resource processing engine.
-  configure:
-    data:
-      engineVersion: "5.7"
 EOF
 
-kubectl apply -f install-app.yaml
+kubectl apply -f install-app-stack.yaml
+```
+
+Create an object to tell the stack to deploy the application:
+
+```
+cat > deploy-app.yaml <<EOF
+apiVersion: wordpress.samples.stacks.crossplane.io/v1alpha1
+kind: WordpressInstance
+metadata:
+  name: "my-wordpress-app-from-go-kustomize"
+  namespace: dev
+spec:
+  engineVersion: "8.0"
+EOF
+
+kubectl apply -f deploy-app.yaml
 ```
 
 #### Option 2: using the helm2 engine
 
-Using the helm2 engine:
+Install the stack:
 
 ```
 cat > install-app.yaml <<EOF
 apiVersion: stacks.crossplane.io/v1alpha1
 kind: StackInstall
 metadata:
-  name: "my-wordpress"
+  name: "my-wordpress-stack-helm2"
   namespace: dev
 spec:
   package: "github.com/suskin/template-stack-experience/wordpress-workload/quick-start/app-stack/helm2"
-  configure:
-    data:
-      engineVersion: "5.7"
 EOF
 
 kubectl apply -f install-app.yaml
+```
+
+Create an object to tell the stack to deploy the application:
+
+```
+cat > deploy-app.yaml <<EOF
+apiVersion: wordpress.samples.stacks.crossplane.io/v1alpha1
+kind: WordpressInstance
+metadata:
+  name: "my-wordpress-app-from-helm2"
+  namespace: dev
+spec:
+  engineVersion: "8.0"
+EOF
+
+kubectl apply -f deploy-app.yaml
 ```
 
 ### Wait and use

--- a/wordpress-workload/quick-start/app-stack/go-kustomize/resources/wordpress.samples.stacks.crossplane.io_wordpressinstances.crd.yaml
+++ b/wordpress-workload/quick-start/app-stack/go-kustomize/resources/wordpress.samples.stacks.crossplane.io_wordpressinstances.crd.yaml
@@ -1,0 +1,53 @@
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  creationTimestamp: null
+  name: wordpressinstances.wordpress.samples.stacks.crossplane.io
+spec:
+  group: wordpress.samples.stacks.crossplane.io
+  names:
+    kind: WordpressInstance
+    plural: wordpressinstances
+  scope: ""
+  validation:
+    openAPIV3Schema:
+      description: WordpressInstance is the Schema for the wordpressinstances API
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: WordpressInstanceSpec defines the desired state of WordpressInstance
+          type: object
+          properties:
+            engineVersion:
+              type: string
+              description: A custom wordpress container image id to use
+              # NOTE defaults are specified like this, using the schema validation for CRD fields.
+              # For more about how this works with CRDs, see:
+              # https://kubernetes.io/docs/tasks/access-kubernetes-api/custom-resources/custom-resource-definitions/#defaulting
+              default: "5.7"
+        status:
+          description: WordpressInstanceStatus defines the observed state of WordpressInstance
+          type: object
+      type: object
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/wordpress-workload/quick-start/app-stack/go-kustomize/stack.yaml
+++ b/wordpress-workload/quick-start/app-stack/go-kustomize/stack.yaml
@@ -1,94 +1,20 @@
 # Stack configuration
 #
 # A stack's configuration contains all of its metadata, plus other configuration.
-#
-# Normally, some of the metadata (such as the name of the stack)
-# would be higher up in the document, but for the purposes
-# of this conceptual demo, the behavioral configuration is at the top instead.
-
 
 # Behaviors specify what should be done in response to different events.
 behaviors:
 
-  # The quick start doesn't use any CRDs, but if we wanted to have behaviors
-  # happen in response to objects being created for specific CRDs, we would configure
-  # that in the behaviors block.
-  # crds:
-  #   wordpressinstance.wordpress.samples.stacks.crossplane.io:
+  engine:
+    type: go-kustomize
 
-  # Lifecycle hooks. These are behaviors which are triggered by specific events occurring.
-  hooks:
-
-    # Configuration lifecycle hook
-    # This hook is triggered when a stack is first installed. The input for any engine is the StackInstall's spec object.
-    configure:
-      # directory
-      # For a docker image-based stack, the directory is the path from the workspace
-      # of the container. An absolute path can also be specified.
-      #
-      # For a github repo, the directory is relative to the root of the repo.
-      #
-      # '..' is not allowed.
-      #
-      # Note that this is a list of hooks, so that a stack can be configured to trigger multiple
-      # hooks for a single lifecycle event.
-      - directory: configure
-
-        # Even though we're specifying a directory for this stack configuration, and bundling it
-        # in our stack, a git url or stack package could also be specified as the source of
-        # the stack. If url or package is specified, directory will be used in the following ways:
-        # - For url: directory will be the directory relative to the repository root.
-        # - For package: directory will be the directory relative to the image's workspace. (An
-        #   absolute directory can also be specified, to be relative to the root of the filesystem.)
-        # url: github.com/crossplaneio/stack-template-wordpress
-        # package: crossplane/stack-template-wordpress:latest
-
-        # This configures the engine which will process the resource files for this stack.
-        # This can be specified at a stack level, or at a per-hook level.
-        #
-        # If it is specified at a per-hook level, the hook will not use any of the configuration
-        # specified at the stack level. Maybe in the future we can figure out a nice way to merge
-        # them if it's used a lot.
-        engine:
-
-          # The engine with which the configuration will be processed.
-          # Accepted engines are: kustomize, go-kustomize, helm2
-          # In some situations, we may be able to infer which engine should be used.
-          type: go-kustomize
-
-          # Configuration is used to configure the specific engine
-          # which was chosen. The subkeys of configuration are specific to the engine which
-          # is selected.
-          configuration:
-
-            # Data will be treated as an interface{} with arbitrary structure, and will be passed
-            # into the go templating engine before the kustomization is applied.
-            #
-            # Data can also be overridden by setting fields on the .spec field of the object
-            # which triggered the resource processing. In the case of a 'configure' event,
-            # the object which triggers it is the StackInstall object.
-            data:
-
-              # Any data set here will be the default for the event, but the default can also be set
-              # by setting a default field value in a CRD's schema.
-              engineVersion: "8.0"
-
-            # This is an escape hatch to allow usage of advanced kustomize functionality directly.
-            # Anything specified in kustomization will be placed into a kustomization.yaml which
-            # is configured to use the stack's kustomization as a base. For the full documentation
-            # of the kustomization.yaml syntax, see:
-            # https://kubectl.docs.kubernetes.io/pages/examples/kustomize.html
-            #
-            # This escape hatch is a speculative part of the design. For entries which reference
-            # files, one could imagine the contents coming from a configMap instead of from a file.
-            # kustomization:
-            #   namePrefix: coolprefix-
-            #   nameSuffix: -coolsuffix
-            #   images:
-            #     name: wordpress
-            #     newTag: 5.3.0-php7.1-fpm-alpine
-            #
-
+  crds:
+    wordpressinstance.wordpress.samples.stacks.crossplane.io:
+      hooks:
+        postCreate:
+          - directory: configure
+        postUpdate:
+          - directory: configure
 
 # Metadata
 #
@@ -101,12 +27,7 @@ behaviors:
 # type: workspace
 
 # Below this point is metadata which is identical to what is currently in app.yaml.
-#
-# In this design, the contents of app.yaml would be moved into stack.yaml, because having
-# a single configuration file with both metadata and behavioral configuration is a familiar
-# pattern for application developers. And because it's easier to find all the configuration
-# if it's all in one place.
-#
+
 # Human readable title of application.
 title: Sample Wordpress Stack
 
@@ -142,3 +63,7 @@ source: "https://github.com/crossplaneio/sample-stack-wordpress"
 
 # License SPDX name: https://spdx.org/licenses/
 license: Apache-2.0
+
+# The dependsOn section isn't filled out in this example, but it would need to
+# be filled out for this stack to work properly.
+# dependsOn:

--- a/wordpress-workload/quick-start/app-stack/helm2/resources/wordpress.samples.stacks.crossplane.io_wordpressinstances.crd.yaml
+++ b/wordpress-workload/quick-start/app-stack/helm2/resources/wordpress.samples.stacks.crossplane.io_wordpressinstances.crd.yaml
@@ -1,0 +1,53 @@
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  creationTimestamp: null
+  name: wordpressinstances.wordpress.samples.stacks.crossplane.io
+spec:
+  group: wordpress.samples.stacks.crossplane.io
+  names:
+    kind: WordpressInstance
+    plural: wordpressinstances
+  scope: ""
+  validation:
+    openAPIV3Schema:
+      description: WordpressInstance is the Schema for the wordpressinstances API
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: WordpressInstanceSpec defines the desired state of WordpressInstance
+          type: object
+          properties:
+            engineVersion:
+              type: string
+              description: A custom wordpress container image id to use
+              # NOTE defaults are specified like this, using the schema validation for CRD fields.
+              # For more about how this works with CRDs, see:
+              # https://kubernetes.io/docs/tasks/access-kubernetes-api/custom-resources/custom-resource-definitions/#defaulting
+              default: "5.7"
+        status:
+          description: WordpressInstanceStatus defines the observed state of WordpressInstance
+          type: object
+      type: object
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/wordpress-workload/quick-start/app-stack/helm2/stack.yaml
+++ b/wordpress-workload/quick-start/app-stack/helm2/stack.yaml
@@ -1,73 +1,20 @@
 # Stack configuration
 #
 # A stack's configuration contains all of its metadata, plus other configuration.
-#
-# Normally, some of the metadata (such as the name of the stack)
-# would be higher up in the document, but for the purposes
-# of this conceptual demo, the behavioral configuration is at the top instead.
-
 
 # Behaviors specify what should be done in response to different events.
 behaviors:
 
-  # The quick start doesn't use any CRDs, but if we wanted to have behaviors
-  # happen in response to objects being created for specific CRDs, we would configure
-  # that in the behaviors block.
-  # crds:
-  #   wordpressinstance.wordpress.samples.stacks.crossplane.io:
+  engine:
+    type: helm2
 
-  # Lifecycle hooks. These are behaviors which are triggered by specific events occurring.
-  hooks:
-
-    # Configuration lifecycle hook
-    # This hook is triggered when a stack is first installed. The input for any engine is the StackInstall's spec object.
-    configure:
-      # directory
-      # For a docker image-based stack, the directory is the path from the workspace
-      # of the container. An absolute path can also be specified.
-      #
-      # For a github repo, the directory is relative to the root of the repo.
-      #
-      # '..' is not allowed.
-      #
-      # Note that this is a list of hooks, so that a stack can be configured to trigger multiple
-      # hooks for a single lifecycle event.
-      - directory: configure
-
-        # Even though we're specifying a directory for this stack configuration, and bundling it
-        # in our stack, a git url or stack package could also be specified as the source of
-        # the stack. If url or package is specified, directory will be used in the following ways:
-        # - For url: directory will be the directory relative to the repository root.
-        # - For package: directory will be the directory relative to the image's workspace. (An
-        #   absolute directory can also be specified, to be relative to the root of the filesystem.)
-        # url: github.com/crossplaneio/stack-template-wordpress
-        # package: crossplane/stack-template-wordpress:latest
-
-        # This configures the engine which will process the resource files for this stack.
-        # This can be specified at a stack level, or at a per-hook level.
-        #
-        # If it is specified at a per-hook level, the hook will not use any of the configuration
-        # specified at the stack level. Maybe in the future we can figure out a nice way to merge
-        # them if it's used a lot.
-        engine:
-
-          # The engine with which the configuration will be processed.
-          # Accepted engines are: kustomize, go-kustomize, helm2
-          # In some situations, we may be able to infer which engine should be used.
-          type: helm2
-
-          # Configuration is used to configure the specific engine
-          # which was chosen. The subkeys of configuration are specific to the engine which
-          # is selected.
-          configuration:
-
-            # The fields of this key will be passed into the helm templating engine as template values.
-            #
-            # Data can also be overridden by setting fields on the .spec field of the object
-            # which triggered the resource processing. In the case of a 'configure' event,
-            # the object which triggers it is the StackInstall object.
-            data:
-              engineVersion: "8.0"
+  crds:
+    wordpressinstance.wordpress.samples.stacks.crossplane.io:
+      hooks:
+        postCreate:
+          - directory: configure
+        postUpdate:
+          - directory: configure
 
 # Metadata
 #
@@ -79,13 +26,6 @@ behaviors:
 # Accepted values: workspace, environment
 # type: workspace
 
-# Below this point is metadata which is identical to what is currently in app.yaml.
-#
-# In this design, the contents of app.yaml would be moved into stack.yaml, because having
-# a single configuration file with both metadata and behavioral configuration is a familiar
-# pattern for application developers. And because it's easier to find all the configuration
-# if it's all in one place.
-#
 # Human readable title of application.
 title: Sample Wordpress Stack
 

--- a/wordpress-workload/quick-start/app-stack/installrequest.yaml
+++ b/wordpress-workload/quick-start/app-stack/installrequest.yaml
@@ -9,26 +9,20 @@ spec:
   # we could also have specified a git url instead.
   package: "crossplane/stack-template-wordpress:master"
 
+  # Speculative design:
+  #
   # A stack can also be installed directly from an image or url
   # which does not have its own stack configuration. In that case,
   # the stack configuration can be specified in the stack install itself.
-  # stackConfiguration:
+  # configuration:
   #   title: "Wordpress Stack"
-  #   configure:
-  #     - directory: configure/
-  #       engine:
-  #         type: go-kustomize
-  #         configuration:
-  #           data:
-  #             imageid: "wordpress:5-fpm-alpine"
+  #   behaviors:
+  #     crds:
+  #     ...
   #
-  # In the case that the stack has a "configure" phase hook, the stack install
-  # can also specify configuration to be passed directly to the engine processing
-  # the hook. The configuration is namespaced so that it doesn't collide with any
-  # other configuration. In a non-install CRD, it would not need to be namespaced
-  # so aggressively, because the CRD may only be used for triggering and configuring
-  # a resource processing engine.
-  # configure:
-  #   data:
-  #     imageid: "wordpress:5-fpm-alpine"
-  #
+  # The reason the design is speculative is because a lot of questions would
+  # need to be answered, and we don't need to answer them yet to get some template
+  # stack functionality working. Questions include:
+  # * What if the CRD files are not in a stack-friendly location or format?
+  # * What if the configuration files are not in a stack-friendly location or format?
+  # * Can we get early validation for the configuration which is being passed in?

--- a/wordpress-workload/quick-start/example.stack.yaml
+++ b/wordpress-workload/quick-start/example.stack.yaml
@@ -1,0 +1,113 @@
+# Stack configuration
+#
+# A stack's configuration contains all of its metadata, plus other configuration.
+#
+# Normally, some of the metadata (such as the name of the stack)
+# would be higher up in the document, but for the purposes
+# of this conceptual demo, the behavioral configuration is at the top instead.
+
+# Behaviors specify what should be done in response to different events.
+behaviors:
+  # This configures the engine which will process the resource files for this stack.
+  # This can be specified in multiple places, and the deepest one wins.
+  #
+  # It can be specified under:
+  # .behaviors.engine
+  # .behaviors.crds.engine
+  # .behaviors.crds.MYCRD.DOMAIN.engine
+  # .behaviors.crds.MYCRD.DOMAIN.hooks.HOOKNAME.[i].engine
+  # (speculative) .behaviors.hooks.HOOKNAME.[i].engine
+  #
+  # If it is specified at a per-hook level, the hook will not use any of the configuration
+  # specified at the stack level. Maybe in the future we can figure out a nice way to merge
+  # them if it's used a lot.
+  engine:
+
+    # The engine with which the configuration will be processed.
+    # Accepted engines are: kustomize, go-kustomize, helm2
+    # In some situations, we may be able to infer which engine should be used.
+    type: go-kustomize
+
+  # Events for crds are namespaced within their own key, to keep them separate from
+  # other types of events.
+  crds:
+
+    # The CRD's KindGroup. This specifies configuration on a per-CRD level, including
+    # engine configuration and hook configuration.
+    resourcepack.gcp.wordpress.samples.stacks.crossplane.io:
+
+      # Configure the hook behaviors for a CRD; each hook corresponds to behavior for a single event.
+      # Supported events:
+      # * postCreate, which is called after an object is created
+      # * postUpdate, which is called after an existing object is changed 
+      hooks:
+
+        # This is the name of the event to configure some behavior for.
+        postCreate:
+          # directory
+          # For a docker image-based stack, the directory is the path from the workspace
+          # of the container. An absolute path can also be specified.
+          #
+          # For a github repo, the directory is relative to the root of the repo.
+          #
+          # '..' is not allowed.
+          #
+          # Note that this is a list of hooks, so that a stack can be configured to trigger multiple
+          # hooks for a single lifecycle event.
+          - directory: configure
+
+        postUpdate:
+          - directory: configure
+
+# Metadata
+#
+# Normally, some of the metadata would be higher up in the document, but for the purposes
+# of this demo, the behavioral configuration is at the top instead.
+#
+# The "type" or "scope" of a stack. This field is commented out as it is still somewhat
+# speculative.
+# Accepted values: workspace, environment
+# type: workspace
+
+# Below this point is metadata which is identical to what is currently in app.yaml.
+#
+# In this design, the contents of app.yaml would be moved into stack.yaml, because having
+# a single configuration file with both metadata and behavioral configuration is a familiar
+# pattern for application developers. And because it's easier to find all the configuration
+# if it's all in one place.
+#
+# Human readable title of application.
+title: Sample Wordpress Stack
+
+overviewShort: Cloud portable Wordpress deployments behind managed Kubernetes and SQL services are demonstrated in this Crossplane Stack.
+overview: |-
+ This Wordpress stack uses a simple controller that uses Crossplane to orchestrate managed SQL services and managed Kubernetes clusters which are then used to run a Wordpress deployment.
+ A simple Custom Resource Definition (CRD) is provided allowing for instances of this Crossplane managed Wordpress Stack to be provisioned with a few lines of yaml.
+ The Sample Wordpress Stack is intended for demonstration purposes and should not be used to deploy production instances of Wordpress.
+
+# Maintainer names and emails.
+maintainers:
+- name: Daniel Suskin
+  email: daniel@upbound.io
+
+# Owner names and emails.
+owners:
+- name: Daniel Suskin
+  email: daniel@upbound.io
+
+# Human readable company name.
+company: Upbound
+
+# Keywords that describe this application and help search indexing
+keywords:
+- "samples"
+- "examples"
+- "tutorials"
+- "wordpress"
+
+# Links to more information about the application (about page, source code, etc.)
+website: "https://upbound.io"
+source: "https://github.com/crossplaneio/sample-stack-wordpress"
+
+# License SPDX name: https://spdx.org/licenses/
+license: Apache-2.0

--- a/wordpress-workload/quick-start/resource-packs/dev/gcp/resources/wordpress.samples.stacks.crossplane.io_resourcepacks.crd.yaml
+++ b/wordpress-workload/quick-start/resource-packs/dev/gcp/resources/wordpress.samples.stacks.crossplane.io_resourcepacks.crd.yaml
@@ -1,0 +1,48 @@
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  creationTimestamp: null
+  name: resourcepacks.gcp.wordpress.samples.stacks.crossplane.io
+spec:
+  group: gcp.wordpress.samples.stacks.crossplane.io
+  names:
+    kind: ResourcePack
+    plural: resourcepacks
+  scope: ""
+  validation:
+    openAPIV3Schema:
+      description: ResourcePack sets up a bunch of GCP infrastructure for running an application
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: ResourcePackSpec defines the desired state of ResourcePack
+          type: object
+          # If the resource pack were set up to take parameters, the schema of the parameters
+          # could be specified here, so that users can get instant schema validation when they
+          # try to apply the resource pack.
+        status:
+          description: ResourcePackStatus defines the observed state of ResourcePack
+          type: object
+      type: object
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/wordpress-workload/quick-start/resource-packs/dev/gcp/stack.yaml
+++ b/wordpress-workload/quick-start/resource-packs/dev/gcp/stack.yaml
@@ -1,91 +1,22 @@
 # Stack configuration
 #
 # A stack's configuration contains all of its metadata, plus other configuration.
-#
-# Normally, some of the metadata (such as the name of the stack)
-# would be higher up in the document, but for the purposes
-# of this conceptual demo, the behavioral configuration is at the top instead.
-
 
 # Behaviors specify what should be done in response to different events.
 behaviors:
 
-  # The quick start doesn't use any CRDs, but if we wanted to have behaviors
-  # happen in response to objects being created for specific CRDs, we would configure
-  # that in the behaviors block.
-  # crds:
-  #   wordpressinstance.wordpress.samples.stacks.crossplane.io:
+  # We're specifying an engine explicitly here, but theoretically we should be
+  # able to infer which engine to use based on the presence of a kustomization.yaml.
+  engine:
+    type: kustomize
 
-  # Lifecycle hooks. These are behaviors which are triggered by specific events occurring.
-  hooks:
-
-    # Configuration lifecycle hook
-    # This hook is triggered when a stack is first installed. The input for any engine is the StackInstall's spec object.
-    configure:
-      # directory
-      # For a docker image-based stack, the directory is the path from the workspace
-      # of the container. An absolute path can also be specified.
-      #
-      # For a github repo, the directory is relative to the root of the repo.
-      #
-      # '..' is not allowed.
-      #
-      # Note that this is a list of hooks, so that a stack can be configured to trigger multiple
-      # hooks for a single lifecycle event.
-      - directory: configure
-
-        # Even though we're specifying a directory for this stack configuration, and bundling it
-        # in our stack, a git url or stack package could also be specified as the source of
-        # the stack. If url or package is specified, directory will be used in the following ways:
-        # - For url: directory will be the directory relative to the repository root.
-        # - For package: directory will be the directory relative to the image's workspace. (An
-        #   absolute directory can also be specified, to be relative to the root of the filesystem.)
-        # url: github.com/crossplaneio/stack-template-wordpress
-        # package: crossplane/stack-template-wordpress:latest
-
-        # This configures the engine which will process the resource files for this stack.
-        # This can be specified at a stack level, or at a per-hook level. If the engine can be inferred
-        # based on the presence of an engine-specific configuration file (such as kustomization.yaml
-        # or Chart.yaml), the engine configuration is optional.
-        #
-        # If it is specified at a per-hook level, the hook will not use any of the configuration
-        # specified at the stack level. Maybe in the future we can figure out a nice way to merge
-        # them if it's used a lot.
-        # engine:
-
-          # The engine with which the configuration will be processed.
-          # Accepted engines are: kustomize, go-kustomize, helm2
-          # In some situations, we may be able to infer which engine should be used.
-          #
-          # In *this* stack, we should be able to infer that the engine should be kustomize, since
-          # there is a kustomization file present.
-          # type: kustomize
-
-          # Configuration is used to configure the specific engine
-          # which was chosen. The subkeys of configuration are specific to the engine which
-          # is selected.
-          # configuration:
-            # This allows usage of advanced kustomize functionality directly.
-            #
-            # Anything specified in kustomization will be placed into a kustomization.yaml which
-            # is configured to use the stack's kustomization as a base. For the full documentation
-            # of the kustomization.yaml syntax, see:
-            # https://kubectl.docs.kubernetes.io/pages/examples/kustomize.html
-            #
-            # This is a speculative part of the design. For entries which reference
-            # files, one could imagine the contents coming from a configMap instead of from a file.
-            #
-            # The kustomization configuration can also be overridden by setting fields on the .spec field of the object
-            # which triggered the resource processing. In the case of a 'configure' event,
-            # the object which triggers it is the StackInstall object.
-            #
-            # kustomization:
-            #   namePrefix: coolprefix-
-            #   nameSuffix: -coolsuffix
-            #   images:
-            #     name: wordpress
-            #     newTag: 5.3.0-php7.1-fpm-alpine
-            #
+  crds:
+    resourcepack.gcp.wordpress.samples.stacks.crossplane.io:
+      hooks:
+        postCreate:
+          - directory: configure
+        postUpdate:
+          - directory: configure
 
 # Metadata
 #
@@ -98,12 +29,7 @@ behaviors:
 # type: workspace
 
 # Below this point is metadata which is identical to what is currently in app.yaml.
-#
-# In this design, the contents of app.yaml would be moved into stack.yaml, because having
-# a single configuration file with both metadata and behavioral configuration is a familiar
-# pattern for application developers. And because it's easier to find all the configuration
-# if it's all in one place.
-#
+
 # Human readable title of application.
 title: Sample Resource Pack for GCP
 
@@ -137,3 +63,7 @@ source: "https://github.com/crossplaneio/sample-gcp-resource-pack"
 
 # License SPDX name: https://spdx.org/licenses/
 license: Apache-2.0
+
+# The dependsOn section isn't filled out in this example, but it would need to
+# be filled out for this stack to work properly.
+# dependsOn:


### PR DESCRIPTION
## Overview

For the quick start, the intent was to only apply template stack configurations when an object is created using a CRD that the stack defines. The previous version was showing what it would look like to apply configuration when the stack is installed.

This change also moves a bunch of commentary out of the stacks' stack.yaml files and into a single `example.stack.yaml` instead.